### PR TITLE
Add run dependency on __cuda virtual package

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
       - fix_ppc64le.patch  # [ppc64le]
 
 build:
-  number: 4
+  number: 5
   string: h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}_{{ build_ext }}
   skip: true  # [win or cuda_compiler_version == "10.2"]
   track_features: {{ "[librealsense-cuda]" if cuda_enabled else "" }}
@@ -37,7 +37,8 @@ requirements:
   host:
     - libudev  # [linux and cdt_name!='cos6']
     - libusb
-
+  run:
+    - __cuda  # [cuda_compiler_version != "None"]
 
 test:
   commands:


### PR DESCRIPTION
Apparently this is best practice to avoid that the cuda package is not installable in systems without cuda, see https://matrix.to/#/!SOyumkgPRWoXfQYIFH:matrix.org/$1677699424135gHvnM:gitter.im?via=matrix.org&via=gitter.im&via=seattlematrix.org .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
